### PR TITLE
Added LED Pin definition to OLEDV2

### DIFF
--- a/LoRaBLE.ino
+++ b/LoRaBLE.ino
@@ -72,6 +72,7 @@
   #define SCK                 5
   #define MISO               19
   #define MOSI               27
+  #define LED                25  // Pin 23 on V2_1.5 or pin 25 on V2_1.6 acording to http://www.lilygo.cn/prod_view.aspx?TypeId=50003&Id=1270&FId=t3:50003:3
 #endif
   
 #ifdef LORAGO


### PR DESCRIPTION
Without the LED you have no indicator of incoming SSDV packets etc. I have confirmed this works on a V2_1.6